### PR TITLE
Fixing size issue and quoting behavior

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,0 @@
-﻿[*.cs]
-
-# IDE0210: Convert to top-level statements
-csharp_style_prefer_top_level_statements = false

--- a/ExcelToCSV/Models/WorksheetPartModel.cs
+++ b/ExcelToCSV/Models/WorksheetPartModel.cs
@@ -26,7 +26,11 @@ internal class WorksheetPartModel
     #endregion
 
     #region Constant Properties
-    private const string NULL_CELL = "\"\"";
+    private const string NULL_CELL = "";
+    #endregion
+
+    #region Static Properties
+    private static List<char> _escapableStrings = [',', '"', (char)13, (char)10];
     #endregion
 
     #region Private Properties
@@ -198,9 +202,18 @@ internal class WorksheetPartModel
         Console.Write($"[{new string('#', completeHashes)}{new string('-', 10 - completeHashes)}]");
         Console.Write($" {percentComplete:P0}");
     }
-
     private static string EscapeString(string str)
     {
+        if (string.IsNullOrEmpty(str))
+        {
+            return str;
+        }
+
+        if (_escapableStrings.Any(str.Contains))
+        {
+            str = $"\"{str}\"";
+        }
+
         return str.Replace("\"", "\"\"");
     }
     private void AddEmptyRows(int rowId, StreamWriter writer)
@@ -256,7 +269,7 @@ internal class WorksheetPartModel
         #endregion
 
         #region Complete Line
-        rowStrings.AddRange(Enumerable.Repeat(NULL_CELL, _rangeReference.EndCellReference.RowNumber - rowStrings.Count));
+        rowStrings.AddRange(Enumerable.Repeat(NULL_CELL, _rangeReference.EndCellReference.ColumnNumber - rowStrings.Count));
         #endregion
 
         #region Indexed
@@ -282,13 +295,13 @@ internal class WorksheetPartModel
                 (CellReferenceModel cellReference, string cellValue) = ParseCell(wsPartReader);
 
                 #region Add Null Cells in Row
-                if (rowStrings.Count < cellReference.ColumnNumber)
+                if ((rowStrings.Count + 1) < cellReference.ColumnNumber)
                 {
-                    rowStrings.AddRange(Enumerable.Repeat(NULL_CELL, cellReference.ColumnNumber - rowStrings.Count));
+                    rowStrings.AddRange(Enumerable.Repeat(NULL_CELL, cellReference.ColumnNumber - (rowStrings.Count + 1)));
                 }
                 #endregion
 
-                rowStrings.Add(string.IsNullOrEmpty(cellValue) ? NULL_CELL : $"\"{cellValue}\"");
+                rowStrings.Add(string.IsNullOrEmpty(cellValue) ? NULL_CELL : cellValue);
             }
         } while (wsPartReader.ReadNextSibling()); //Cells
         #endregion

--- a/ExcelToCSV/Program.cs
+++ b/ExcelToCSV/Program.cs
@@ -5,7 +5,6 @@ using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/ExcelToCSV/Properties/launchSettings.json
+++ b/ExcelToCSV/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ExcelToCSV": {
       "commandName": "Project",
-      "commandLineArgs": "--help"
+      "commandLineArgs": "\"C:\\Users\\jaysu\\Desktop\\test\\test3.xlsx\""
     }
   }
 }


### PR DESCRIPTION
A reference to row number rather than column number was writing a ton of empty columns. I also changed the quoting behavior from "always quote" to "quote on double quotes, or commas, or new lines". That change may have to be rescinded over time if quoting becomes too complicated.